### PR TITLE
new: add notification hook

### DIFF
--- a/conf/system/settings.ini
+++ b/conf/system/settings.ini
@@ -21,3 +21,5 @@ prefercaster=False
 preferelite=False
 
 GameDir=
+
+notificationURL=

--- a/conf/user/settings.sample.ini
+++ b/conf/user/settings.sample.ini
@@ -34,3 +34,5 @@ stopAtBossFight=False
 stopAtStranger=False
 
 GameDir=
+
+notificationURL=

--- a/modules/bounty.py
+++ b/modules/bounty.py
@@ -20,6 +20,7 @@ from .campfire import look_at_campfire_completed_tasks
 from .log_board import LogHSMercs
 from .settings import settings_dict, jposition, jthreshold
 from .treasure import chooseTreasure
+from .notification import send_notification
 
 import logging
 
@@ -102,6 +103,7 @@ def nextlvl():
             time.sleep(7)
             while find_ellement(UIElement.visitor.filename, Action.screenshot):
                 if settings_dict["stopatstranger"]:
+                    send_notification({"message": "Stopping after meeting Mysterious Stranger"})
                     log.info("Stopping after meeting Mysterious Stranger")
                     sys.exit()
 
@@ -253,6 +255,7 @@ def goToEncounter():
             if settings_dict["stopatbossfight"] is True and find_ellement(
                 UIElement.boss.filename, Action.screenshot
             ):
+                send_notification({"message": "Stopping before Boos battle."})
                 log.info("Stopping before Boos battle.")
                 sys.exit()
 

--- a/modules/notification.py
+++ b/modules/notification.py
@@ -1,0 +1,24 @@
+from urllib import request, parse, error
+
+from .settings import settings_dict
+
+import logging
+
+log = logging.getLogger(__name__)
+
+def send_notification(message: dict):
+    """Send notification message to a webhook url from `notificationURL` config."""
+    if not settings_dict['notificationurl']:
+        return
+    url = settings_dict['notificationurl']
+    try:
+        data = parse.urlencode(message).encode()
+        req = request.Request(url, data, method="POST")
+        request.urlopen(req)
+        log.info(f"notification sent: {message}")
+    except error.HTTPError as e:
+        log.error(f"notification HTTP error: {e.code}")
+    except error.URLError as e:
+        log.error(f"notification URL error: {e.reason}")
+    except Exception as e:
+        log.error(f"notification error: {e}")

--- a/tests/unit/settings/test_settings.ini
+++ b/tests/unit/settings/test_settings.ini
@@ -10,3 +10,5 @@ WaitForEXP = 0
 quitBeforeBossFight=False
 stopAtStranger=False
 GameDir=C:/Test/Location/Hearthstone
+notificationURL=https://example.com
+zonelog=C:/Test/Location/Hearthstone/Logs/Zone.log

--- a/tests/unit/settings/test_settings.py
+++ b/tests/unit/settings/test_settings.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import patch
 from pathlib import Path
 
-from modules.settings.settings import (
+from modules.settings.conf.settings import (
     get_settings,
     copy_config_from_sample_if_not_exists,
 )
@@ -29,6 +29,7 @@ class TestSettings(unittest.TestCase):
             "stopatstranger": False,
             "waitforexp": 0,
             "zonelog": "C:/Test/Location/Hearthstone/Logs/Zone.log",
+            "notificationurl": "https://example.com",
         }
 
         self.assertEqual(actual_settings_dict, expected_settings_dict)

--- a/tests/unit/settings/test_settings_missing_gamedir.ini
+++ b/tests/unit/settings/test_settings_missing_gamedir.ini
@@ -10,3 +10,4 @@ WaitForEXP = 0
 quitBeforeBossFight=False
 stopAtStranger=False
 GameDir=c:\location\that\doesnt\exist
+notificationURL=https://example.com

--- a/tests/unit/settings/test_settings_no_gamedir.ini
+++ b/tests/unit/settings/test_settings_no_gamedir.ini
@@ -10,3 +10,4 @@ WaitForEXP = 0
 quitBeforeBossFight=False
 stopAtStranger=False
 GameDir=
+notificationURL=https://example.com


### PR DESCRIPTION
Add a notification hook when the bot stops. 

Personally, I use [ifttt](https://ifttt.com/) to create the webhook notification.

When the bot stops it will send the POST HTTP request to the webhook URL with the body message.

Also, the unit test failed. it seems like it hasn't succeeded for a while.