### PR TITLE
Fix/new resolution

### DIFF
--- a/conf/system/settings.ini
+++ b/conf/system/settings.ini
@@ -2,7 +2,7 @@
 ## create (or copy "settings.sample.ini" into) "settings.ini" in "conf/user/" directory
 [BotSettings]
 monitor=1
-Monitor Resolution = 1920x1080
+Resolution=1920x1080
 bot_speed=0.1
 MouseSpeed = 0.3
 

--- a/conf/user/settings.sample.ini
+++ b/conf/user/settings.sample.ini
@@ -3,7 +3,7 @@
 [BotSettings]
 
 monitor=1
-Monitor Resolution = 1920x1080
+Resolution=1920x1080
 bot_speed=0.1
 MouseSpeed = 0.3
 

--- a/modules/encounter.py
+++ b/modules/encounter.py
@@ -7,7 +7,7 @@ import logging
 from .platform import windowMP
 from .mouse_utils import move_mouse_and_click, move_mouse, mouse_click  # , mouse_scroll
 
-from .image_utils import partscreen, find_ellement
+from .image_utils import partscreen, find_ellement, get_resolution
 from .constants import UIElement, Button, Action
 from .game import countdown, waitForItOrPass
 # from .log_board import LogHSMercs
@@ -175,11 +175,13 @@ def didnt_find_a_name_for_this_one(name, minionSection, turn, defaultAbility=0):
             f"abilities Y : {abilitiesPositionY} |"
             f" abilities X : {abilitiesPositionX}"
         )
+        _, _, _, scale_size = get_resolution()
         partscreen(
             int(abilitiesWidth),
             int(abilitiesHeigth),
             int(windowMP()[1] + abilitiesPositionY),
             int(windowMP()[0] + abilitiesPositionX[0]),
+            scale_size=scale_size,
         )
         if (
             find_ellement(UIElement.hourglass.filename, Action.get_coords_part_screen)
@@ -469,7 +471,14 @@ def battle(zoneLog=None):
             time.sleep(0.5)
 
             # tmp = int(windowMP()[3] / 2)
-            partscreen(windowMP()[2], windowMP()[3] // 2, windowMP()[1], windowMP()[0])
+            _, _, _, scale_size = get_resolution()
+            partscreen(
+                windowMP()[2],
+                windowMP()[3] // 2,
+                windowMP()[1],
+                windowMP()[0],
+                scale_size=scale_size,
+            )
 
             (
                 enemyred,

--- a/modules/image_utils.py
+++ b/modules/image_utils.py
@@ -1,3 +1,4 @@
+import sys
 import os.path
 
 import cv2
@@ -20,6 +21,27 @@ default_rect = (0, 69, 1920, 1011)
 default_width = default_rect[2] - default_rect[0]
 default_height = default_rect[3] - default_rect[1]
 
+def get_resolution() -> tuple[str, int, int, float]:
+    """
+    Get the resolution of the screen
+    return tuple(resolution, width, height, scale_size)
+    """
+    try:
+        resolution = settings_dict["resolution"]
+        setting_size = resolution.split("x")
+        setting_w, setting_h = int(setting_size[0]), int(setting_size[1])
+        windows_w, windows_h = windowMP()[2], windowMP()[3]
+        if round(windows_w / setting_w, 2) != round(windows_h / setting_h, 2):
+            raise Exception("setting resolution and windows resolution are not the same aspect ratio")
+        scale_size = setting_w / windows_w
+        return resolution, setting_w, setting_h, scale_size
+    except Exception as e:
+        log.error(f"the resolution {resolution} not support: {e}")
+        sys.exit()
+
+def resize(img, width, height):
+    """resize an image"""
+    return cv2.resize(img, (width, height), interpolation=cv2.INTER_CUBIC)
 
 def get_gray_image(file, width=default_width, height=default_height):
     """load an OpenCV version of an image in memory and/or return it"""
@@ -108,16 +130,24 @@ def find_element_from_file(
         else:
             threshold = jthreshold["default_grey"]
 
+    resolution, width, height, scale_size = get_resolution()
+
     # choose if the bot need to look into the screen or in a part of the screen
     if new_screenshot:
-        partscreen(windowMP()[2], windowMP()[3], windowMP()[1], windowMP()[0])
+        partscreen(
+            windowMP()[2],
+            windowMP()[3],
+            windowMP()[1],
+            windowMP()[0],
+            resize_width=width,
+            resize_height=height,
+        )
 
     img = cv2.cvtColor(partImg, cv2.COLOR_BGR2GRAY)
-    monitor_resolution = settings_dict["monitor resolution"]
 
-    template = get_gray_image(f"files/{monitor_resolution}/{file}")
+    template = get_gray_image(f"files/{resolution}/{file}")
 
-    click_coords = find_element_center_on_screen(img, template, threshold=threshold)
+    click_coords = find_element_center_on_screen(img, template, threshold, scale_size)
 
     if click_coords is not None:
         log.info(
@@ -129,7 +159,7 @@ def find_element_from_file(
     return click_coords
 
 
-def partscreen(x, y, top, left, debug_mode=False, monitor_resolution=None):
+def partscreen(x, y, top, left, debug_mode=False, resolution=None, resize_width=None, resize_height=None, scale_size=1):
     """
     take screeenshot for a part of the screen to find some part of the image
     """
@@ -141,13 +171,20 @@ def partscreen(x, y, top, left, debug_mode=False, monitor_resolution=None):
         sct_img = sct.grab(monitor)
 
         if debug_mode:
-            output_file = f"files/{ monitor_resolution}/part.png"
+            output_file = f"files/{ resolution}/part.png"
             mss.tools.to_png(sct_img.rgb, sct_img.size, output=output_file)
+
         partImg = np.array(sct_img)
+
+        if resize_width and resize_height:
+            partImg = cv2.resize(partImg, (resize_width, resize_height), interpolation=cv2.INTER_CUBIC)
+        elif scale_size != 1:
+            partImg = cv2.resize(partImg, (int(x * scale_size), int(y * scale_size)), interpolation=cv2.INTER_CUBIC)
+    
     return partImg
 
 
-def find_element_center_on_screen(img, template, threshold=0):
+def find_element_center_on_screen(img, template, threshold=0, scale_size=1):
     """Finds Element if on screen and returns center
 
     Args:
@@ -164,4 +201,4 @@ def find_element_center_on_screen(img, template, threshold=0):
     w = template.shape[1] // 2
     _, max_val, _, max_loc = cv2.minMaxLoc(result)
 
-    return (max_loc[0] + w, max_loc[1] + h) if max_val > threshold else None
+    return ((max_loc[0] + w) / scale_size, (max_loc[1] + h) / scale_size) if max_val > threshold else None

--- a/new_resolution.py
+++ b/new_resolution.py
@@ -25,7 +25,8 @@ new_resolution = settings_dict["monitor resolution"]
 
 ox, oy = orig_resolution.split("x")
 nx, ny = new_resolution.split("x")
-if int(ox) / int(oy) == int(nx) / int(ny) and orig_resolution != new_resolution:
+
+if round(int(ox) / int(oy), 2) == round(int(nx) / int(ny), 2) and orig_resolution != new_resolution:
     copy_dir_and_func_files(
         BASEDIR,
         orig_resolution,

--- a/new_resolution.py
+++ b/new_resolution.py
@@ -21,7 +21,7 @@ def resize_image(srcfile, dstfile, params=[]):
     cv2.imwrite(dstfile, imgresized)
 
 
-new_resolution = settings_dict["monitor resolution"]
+new_resolution = settings_dict["resolution"]
 
 ox, oy = orig_resolution.split("x")
 nx, ny = new_resolution.split("x")

--- a/tests/unit/settings/test_settings.ini
+++ b/tests/unit/settings/test_settings.ini
@@ -1,6 +1,6 @@
 [BotSettings]
 monitor=1
-Monitor Resolution = 1920x1080
+Resolution=1920x1080
 bot_speed=0.1
 MouseSpeed = 0.3
 location=The Barrens

--- a/tests/unit/settings/test_settings.py
+++ b/tests/unit/settings/test_settings.py
@@ -23,7 +23,7 @@ class TestSettings(unittest.TestCase):
             "location": "The Barrens",
             "mode": "Heroic",
             "monitor": 1,
-            "monitor resolution": "1920x1080",
+            "resolution": "1920x1080",
             "mousespeed": 0.3,
             "quitbeforebossfight": False,
             "stopatstranger": False,

--- a/tests/unit/settings/test_settings_missing_gamedir.ini
+++ b/tests/unit/settings/test_settings_missing_gamedir.ini
@@ -1,6 +1,6 @@
 [BotSettings]
 monitor=1
-Monitor Resolution = 1920x1080
+Resolution=1920x1080
 bot_speed=0.1
 MouseSpeed = 0.3
 location=The Barrens

--- a/tests/unit/settings/test_settings_no_gamedir.ini
+++ b/tests/unit/settings/test_settings_no_gamedir.ini
@@ -1,6 +1,6 @@
 [BotSettings]
 monitor=1
-Monitor Resolution = 1920x1080
+Resolution=1920x1080
 bot_speed=0.1
 MouseSpeed = 0.3
 location=The Barrens


### PR DESCRIPTION
only work with 16:9 for now

I prefer the same screen size and resolution for better performance to avoid resizing the screenshot.
I tried very low resolution 683x384, but some of the objects don't match for .85 threshold. work when reduce to .7.

Changes:
- Config name `Monitor Reposolution` to `Resolution`
- Add 16:9 screen resolution support (bigger than 1080p also work)

Todo:
- Auto gen images temp files resolution from config 
- Performance optimization


