### PR TITLE
use virtual env to isolate python dependencies

### DIFF
--- a/HSbotRunner_venv.bat
+++ b/HSbotRunner_venv.bat
@@ -1,0 +1,4 @@
+python -m venv %~dp0MFB
+%~dp0MFB\Scripts\python.exe -m pip install -r requirements_win.txt
+%~dp0MFB\Scripts\python.exe main.py
+pause

--- a/HSbotRunner_venv.sh
+++ b/HSbotRunner_venv.sh
@@ -1,0 +1,3 @@
+python3.10 -m venv MFB
+./MFB/Scripts/python -m pip install -r requirements_linux.txt
+./MFB/Scripts/python main.py


### PR DESCRIPTION
Created new launch scripts that use venv to isolate the dependencies

- Create venv under main folder called MFB
- Due to restrictions for calling commands once the venv is activated relative paths are being used.

Possible improvements would be to add a configuration setting to specify where the venv needs to be installed and populate the launch script with the options.